### PR TITLE
Configurable HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,20 @@ favor frequent calls to limited number of endpoints.
 ok = application:set_env(current, http_client, lhttpc).
 ```
 
-Example of party raw socket:
+Example using party raw socket:
+
+New [party][] raw socket is created and set automatically:
 ```erlang
 ok = application:set_env(current, http_client, party).
-{ok, Socket} = current:open_socket(<<"http://dynamodb.us-east-1.amazonaws.com">>, raw).
-ok = current:close_socket(Socket, raw).
+{ok, Socket} = current:open_socket(<<"http://dynamodb.us-east-1.amazonaws.com">>, party_socket).
+ok = current:close_socket(Socket, party_socket).
+
+```
+
+An exiting [party][] raw socket is passed using options:
+```erlang
+current:describe_table({[{<<"TableName">>, <<"current_test_table">>}]},
+                                           [{party_socket, Socket}]]).
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ favor frequent calls to limited number of endpoints.
 ok = application:set_env(current, http_client, lhttpc).
 ```
 
-Example of party raw sockett:
+Example of party raw socket:
 ```erlang
 ok = application:set_env(current, http_client, party).
 {ok, Socket} = current:open_socket(<<"http://dynamodb.us-east-1.amazonaws.com">>, raw).

--- a/README.md
+++ b/README.md
@@ -85,22 +85,27 @@ favor frequent calls to limited number of endpoints.
 ok = application:set_env(current, http_client, lhttpc).
 ```
 
-Example using party raw socket:
-
 New [party][] raw socket is created and set automatically:
 ```erlang
 ok = application:set_env(current, http_client, party).
-{ok, Socket} = current:open_socket(<<"http://dynamodb.us-east-1.amazonaws.com">>, party_socket).
+{ok, Socket} = current:open_socket(<<"http://dynamodb.us-east-1.amazonaws.com">>,
+     party_socket).
 ok = current:close_socket(Socket, party_socket).
 
 ```
 
-An exiting [party][] raw socket is passed using options:
+An exiting [party][] raw socket is passed as an option:
 ```erlang
 current:describe_table({[{<<"TableName">>, <<"current_test_table">>}]},
                                            [{party_socket, Socket}]]).
 
 ```
+
+An exiting [party][] raw socket is set using application configuration parameter:
+```erlang
+ok = application:set_env(current, party_socket, Socket).
+```
+
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Example of party raw socket:
 ```erlang
 ok = application:set_env(current, http_client, party).
 {ok, Socket} = current:open_socket(<<"http://dynamodb.us-east-1.amazonaws.com">>, raw).
-ok = proplists:set_value(current, party_socket, Socket).
 ok = current:close_socket(Socket, raw).
 
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Example usage:
 ```erlang
 1> application:ensure_all_started(current).
 {ok,[party,current]}
-2> party:connect(<<"http://dynamodb.us-east-1.amazonaws.com">>, 2).
+2> current:connect(<<"http://dynamodb.us-east-1.amazonaws.com">>, 2).
 ok
 3> application:set_env(current, region, <<"us-east-1">>).
 ok
@@ -77,6 +77,23 @@ to ```TOTAL``` by default. When DynamoDB returns the
 module. Keep in mind that for batch requests it is a list containing
 capacity for one or more tables.
 
+## Configurable HTTP client
+You can use either [`party`][] or [`lhttpc`][] HTTP client. Both clients
+favor frequent calls to limited number of endpoints.
+
+```erlang
+ok = application:set_env(current, http_client, lhttpc).
+```
+
+Example of party raw sockett:
+```erlang
+ok = application:set_env(current, http_client, party).
+{ok, Socket} = current:open_socket(<<"http://dynamodb.us-east-1.amazonaws.com">>, raw).
+ok = proplists:set_value(current, party_socket, Socket).
+ok = current:close_socket(Socket, raw).
+
+```
+
 
 ## Testing
 
@@ -94,3 +111,5 @@ To run all tests use `rebar eunit`
 [rebar]: https://github.com/rebar/rebar
 [Java JRE]: http://java.com/en/
 [screen]: https://www.gnu.org/software/screen/
+[party]: https://github.com/GameAnalytics/party.git
+[lhttpc]: https://github.com/ferd/lhttpc.git

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ module. Keep in mind that for batch requests it is a list containing
 capacity for one or more tables.
 
 ## Configurable HTTP client
-You can use either [`party`][] or [`lhttpc`][] HTTP client. Both clients
+You can use either [party][] or [lhttpc][] HTTP client. Both clients
 favor frequent calls to limited number of endpoints.
 
 ```erlang

--- a/README.md
+++ b/README.md
@@ -105,11 +105,9 @@ To run all tests use `rebar eunit`
 
 
 [jiffy]: https://github.com/davisp/jiffy
-[party]: https://github.com/knutin/party
+[party]: https://github.com/GameAnalytics/party
 [lhttpc]: https://github.com/ferd/lhttpc
 [DynamoDB documentation]: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/Welcome.html
 [rebar]: https://github.com/rebar/rebar
 [Java JRE]: http://java.com/en/
 [screen]: https://www.gnu.org/software/screen/
-[party]: https://github.com/GameAnalytics/party.git
-[lhttpc]: https://github.com/ferd/lhttpc.git

--- a/rebar.config
+++ b/rebar.config
@@ -2,11 +2,18 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-        {party, ".*", {git, "git://github.com/GameAnalytics/party.git", {branch, "master"}}},
-        {jiffy, "", {git, "https://github.com/davisp/jiffy.git", {branch, "master"}}},
-        {edatetime, "", {git, "https://github.com/GameAnalytics/edatetime.git", {branch, "master"}}},
-        {erlsha2, "", {git, "https://github.com/vinoski/erlsha2.git", {branch, "master"}}},
-        {meck, "", {git, "git://github.com/eproxus/meck.git", {branch, "master"}}}
+        {party, ".*",
+           {git, "git://github.com/GameAnalytics/party.git", {branch, "master"}}},
+        {lhttpc, "",
+           {git, "https://github.com/ferd/lhttpc.git", {branch, "master"}}},
+        {jiffy, "",
+           {git, "https://github.com/davisp/jiffy.git", {branch, "master"}}},
+        {edatetime, "",
+           {git, "https://github.com/GameAnalytics/edatetime.git", {branch, "master"}}},
+        {erlsha2, "",
+           {git, "https://github.com/vinoski/erlsha2.git", {branch, "master"}}},
+        {meck, "",
+           {git, "git://github.com/eproxus/meck.git", {branch, "master"}}}
        ]}.
 
 {pre_hooks, [

--- a/rebar.config
+++ b/rebar.config
@@ -3,9 +3,10 @@
 
 {deps, [
         {party, ".*",
-           {git, "git://github.com/GameAnalytics/party.git", {branch, "master"}}},
+           {git, "https://github.com/GameAnalytics/party.git", {branch, "master"}}},
         {lhttpc, "",
            {git, "https://github.com/ferd/lhttpc.git", {branch, "master"}}},
+
         {jiffy, "",
            {git, "https://github.com/davisp/jiffy.git", {branch, "master"}}},
         {edatetime, "",
@@ -13,7 +14,7 @@
         {erlsha2, "",
            {git, "https://github.com/vinoski/erlsha2.git", {branch, "master"}}},
         {meck, "",
-           {git, "git://github.com/eproxus/meck.git", {branch, "master"}}}
+           {git, "https://github.com/eproxus/meck.git", {branch, "master"}}}
        ]}.
 
 {pre_hooks, [

--- a/src/current.app.src
+++ b/src/current.app.src
@@ -7,6 +7,7 @@
                   kernel,
                   stdlib,
                   party,
+                  lhttpc,
                   jiffy,
                   edatetime,
                   erlsha2

--- a/src/current.erl
+++ b/src/current.erl
@@ -359,11 +359,11 @@ do_query({UserRequest}, Acc, Opts) ->
             {error, Reason}
     end.
 
-get_accumulate_fun(true) ->
+get_accumulate_fun(_IsCount = true) ->
     fun (Count, undefined) -> Count;
         (Count, A) -> Count + A
     end;
-get_accumulate_fun(false) ->
+get_accumulate_fun(_IsCount = false) ->
     fun (Items, undefined) -> Items;
         (Items, A) -> Items ++ A
     end.

--- a/src/current.erl
+++ b/src/current.erl
@@ -110,6 +110,7 @@ connect(Endpoint, ConnLimit) ->
         true ->
             ok = party:connect(Endpoint, ConnLimit);
         false ->
+            %%NOTE: lhttpc does not support connect concept
             ok
     end.
 
@@ -122,8 +123,9 @@ disconnect(Endpoint) ->
             ok
     end.
 
-%%TODO: what about prefix it with party_ to make function obvious
--spec open_socket(any(), atom()) -> {ok, pid()} | {error, atom()}.
+%%TODO: what about prefix it with party_ to make function obvious?
+%%TODO: what about setting socket to party_socket
+-spec open_socket(any(), atom()) -> {ok, pid()} | {errorp, atom()}.
 open_socket(undefined, _Type) ->
     {error, missing_endpoint};
 open_socket(Endpoint, raw) ->

--- a/src/current.erl
+++ b/src/current.erl
@@ -596,9 +596,9 @@ config_secret_key() ->
 config_callback_mod() ->
     application:get_env(current, callback_mod, current_callback).
 
-%% Options
-opts_timeout(Opts)     -> proplists:get_value(timeout, Opts, 5000).
-opts_retries(Opts)     -> proplists:get_value(retries, Opts, 3).
+%% Query Options
+opts_timeout(Opts)     -> proplists:get_value(timeout,     Opts, 5000).
+opts_retries(Opts)     -> proplists:get_value(retries,     Opts, 3).
 opts_max_backoff(Opts) -> proplists:get_value(max_backoff, Opts, 60000).
 
 %% Formatting helpers

--- a/src/current.erl
+++ b/src/current.erl
@@ -127,7 +127,7 @@ disconnect(Endpoint) ->
 -spec open_socket(any(), atom()) -> {ok, pid()} | {error, atom()}.
 open_socket(undefined, _Type) ->
     {error, missing_endpoint};
-open_socket(Endpoint, raw) ->
+open_socket(Endpoint, party_socket) ->
     case current_http_client:is_party_active() of
         true  ->
             {ok, SocketPid} = party_socket_raw:start_link(Endpoint),
@@ -150,7 +150,7 @@ open_socket(Endpoint, _Plain) ->
     end.
 
 -spec close_socket(pid(), atom()) -> ok.
-close_socket(Socket, raw) ->
+close_socket(Socket, party_socket) ->
     party_socket_raw:stop(Socket);
 close_socket(_Socket, _Plain) ->
     ok.

--- a/src/current.erl
+++ b/src/current.erl
@@ -104,23 +104,23 @@ update_table(Request, Opts)          -> retry(update_table, Request, Opts).
 %% PARTY RAW SOCKET WRAPPERS
 %%
 
--spec connect(iolist(), pos_integer()) -> ok.
+-spec connect(iolist(), pos_integer()) -> ok | {error, connect_not_supported}.
 connect(Endpoint, ConnLimit) ->
     case current_http_client:is_party_active() of
         true ->
             ok = party:connect(Endpoint, ConnLimit);
         false ->
             %%NOTE: lhttpc does not support connect concept
-            ok
+            {error, connect_not_supported}
     end.
 
--spec disconnect(iolist()) -> ok.
+-spec disconnect(iolist()) -> ok | {error, connect_not_supported}.
 disconnect(Endpoint) ->
     case current_http_client:is_party_active() of
         true ->
             ok = party:disconnect(Endpoint);
         false ->
-            ok
+            {error, connect_not_supported}
     end.
 
 %%TODO: what about prefix it with party_ to make function obvious?

--- a/src/current.erl
+++ b/src/current.erl
@@ -32,6 +32,7 @@
          update_table/2
         ]).
 
+-export([connect/2, disconnect/1]).
 -export([open_socket/2, close_socket/2]).
 -export([wait_for_delete/2, wait_for_active/2]).
 
@@ -103,6 +104,25 @@ update_table(Request, Opts)          -> retry(update_table, Request, Opts).
 %% PARTY RAW SOCKET WRAPPERS
 %%
 
+-spec connect(iolist(), pos_integer()) -> ok.
+connect(Endpoint, ConnLimit) ->
+    case current_http_client:is_party_active() of
+        true ->
+            ok = party:connect(Endpoint, ConnLimit);
+        false ->
+            ok
+    end.
+
+-spec disconnect(iolist()) -> ok.
+disconnect(Endpoint) ->
+    case current_http_client:is_party_active() of
+        true ->
+            ok = party:disconnect(Endpoint);
+        false ->
+            ok
+    end.
+
+%%TODO: what about prefix it with party_ to make function obvious
 -spec open_socket(any(), atom()) -> {ok, pid()} | {error, atom()}.
 open_socket(undefined, _Type) ->
     {error, missing_endpoint};

--- a/src/current.erl
+++ b/src/current.erl
@@ -64,10 +64,10 @@
 
 -export_type([target/0, request/0]).
 
+
 %%
 %% LOW-LEVEL API
 %%
-
 
 batch_get_item(Request)              -> do_batch_get_item(Request, []).
 batch_get_item(Request, Opts)        -> do_batch_get_item(Request, Opts).

--- a/src/current.erl
+++ b/src/current.erl
@@ -1,7 +1,6 @@
 %% @doc: DynamoDB client
 -module(current).
 
-
 %% DynamoDB API
 -export([
          batch_get_item/1,
@@ -70,34 +69,34 @@
 %%
 
 
-batch_get_item(Request)         -> do_batch_get_item(Request, []).
-batch_get_item(Request, Opts)   -> do_batch_get_item(Request, Opts).
-batch_write_item(Request)       -> do_batch_write_item(Request, []).
-batch_write_item(Request, Opts) -> do_batch_write_item(Request, Opts).
+batch_get_item(Request)              -> do_batch_get_item(Request, []).
+batch_get_item(Request, Opts)        -> do_batch_get_item(Request, Opts).
+batch_write_item(Request)            -> do_batch_write_item(Request, []).
+batch_write_item(Request, Opts)      -> do_batch_write_item(Request, Opts).
 batch_write_item_once(Request, Opts) -> retry(batch_write_item, Request, Opts).
-create_table(Request)           -> retry(create_table, Request, []).
-create_table(Request, Opts)     -> retry(create_table, Request, Opts).
-delete_item(Request)            -> retry(delete_item, Request, []).
-delete_item(Request, Opts)      -> retry(delete_item, Request, Opts).
-delete_table(Request)           -> retry(delete_table, Request, []).
-delete_table(Request, Opts)     -> retry(delete_table, Request, Opts).
-describe_table(Request)         -> retry(describe_table, Request, []).
-describe_table(Request, Opts)   -> retry(describe_table, Request, Opts).
-get_item(Request)               -> retry(get_item, Request, []).
-get_item(Request, Opts)         -> retry(get_item, Request, Opts).
-list_tables(Request)            -> retry(list_tables, Request, []).
-list_tables(Request, Opts)      -> retry(list_tables, Request, Opts).
-put_item(Request)               -> retry(put_item, Request, []).
-put_item(Request, Opts)         -> retry(put_item, Request, Opts).
-q(Request)                      -> do_query(Request, []).
-q(Request, Opts)                -> do_query(Request, Opts).
-scan_once(Request, Opts)        -> retry(scan, Request, Opts).
-scan(Request)                   -> do_scan(Request, []).
-scan(Request, Opts)             -> do_scan(Request, Opts).
-update_item(Request)            -> retry(update_item, Request, []).
-update_item(Request, Opts)      -> retry(update_item, Request, Opts).
-update_table(Request)           -> retry(update_table, Request, []).
-update_table(Request, Opts)     -> retry(update_table, Request, Opts).
+create_table(Request)                -> retry(create_table, Request, []).
+create_table(Request, Opts)          -> retry(create_table, Request, Opts).
+delete_item(Request)                 -> retry(delete_item, Request, []).
+delete_item(Request, Opts)           -> retry(delete_item, Request, Opts).
+delete_table(Request)                -> retry(delete_table, Request, []).
+delete_table(Request, Opts)          -> retry(delete_table, Request, Opts).
+describe_table(Request)              -> retry(describe_table, Request, []).
+describe_table(Request, Opts)        -> retry(describe_table, Request, Opts).
+get_item(Request)                    -> retry(get_item, Request, []).
+get_item(Request, Opts)              -> retry(get_item, Request, Opts).
+list_tables(Request)                 -> retry(list_tables, Request, []).
+list_tables(Request, Opts)           -> retry(list_tables, Request, Opts).
+put_item(Request)                    -> retry(put_item, Request, []).
+put_item(Request, Opts)              -> retry(put_item, Request, Opts).
+q(Request)                           -> do_query(Request, []).
+q(Request, Opts)                     -> do_query(Request, Opts).
+scan_once(Request, Opts)             -> retry(scan, Request, Opts).
+scan(Request)                        -> do_scan(Request, []).
+scan(Request, Opts)                  -> do_scan(Request, Opts).
+update_item(Request)                 -> retry(update_item, Request, []).
+update_item(Request, Opts)           -> retry(update_item, Request, Opts).
+update_table(Request)                -> retry(update_table, Request, []).
+update_table(Request, Opts)          -> retry(update_table, Request, Opts).
 
 
 
@@ -138,9 +137,6 @@ wait_for_delete(Table, Timeout) ->
 %% ============================================================================
 %% IMPLEMENTATION
 %% ============================================================================
-
-
-
 
 %%
 %% BATCH GET AND WRITE
@@ -290,22 +286,13 @@ do_query(Request, Opts) ->
     do_query(Request, undefined, Opts).
 
 do_query({UserRequest}, Acc, Opts) ->
-    IsCount = proplists:get_value(<<"Select">>, UserRequest) =:= <<"COUNT">>,
-    Accumulate = case IsCount of
-                     true ->
-                         fun (Count, undefined) -> Count;
-                             (Count, A) -> Count + A
-                         end;
-                     false ->
-                         fun (Items, undefined) -> Items;
-                             (Items, A) -> Items ++ A
-                         end
-                 end,
+    IsCount    = proplists:get_value(<<"Select">>, UserRequest) =:= <<"COUNT">>,
+    Accumulate = get_accumulate_fun(IsCount),
 
     case retry('query', {UserRequest}, Opts) of
         {ok, {Response}} ->
             Result = case IsCount of
-                         true -> proplists:get_value(<<"Count">>, Response);
+                         true  -> proplists:get_value(<<"Count">>, Response);
                          false -> proplists:get_value(<<"Items">>, Response)
                      end,
             case proplists:get_value(<<"LastEvaluatedKey">>, Response) of
@@ -326,9 +313,14 @@ do_query({UserRequest}, Acc, Opts) ->
             {error, Reason}
     end.
 
-
-
-
+get_accumulate_fun(true) ->
+    fun (Count, undefined) -> Count;
+        (Count, A) -> Count + A
+    end;
+get_accumulate_fun(false) ->
+    fun (Items, undefined) -> Items;
+        (Items, A) -> Items ++ A
+    end.
 
 
 
@@ -341,17 +333,8 @@ do_scan(Request, Opts) ->
     do_scan(Request, undefined, Opts).
 
 do_scan({UserRequest}, Acc, Opts) ->
-    IsCount = proplists:get_value(<<"Select">>, UserRequest) =:= <<"COUNT">>,
-    Accumulate = case IsCount of
-                     true ->
-                         fun (Count, undefined) -> Count;
-                             (Count, A) -> Count + A
-                         end;
-                     false ->
-                         fun (Items, undefined) -> Items;
-                             (Items, A) -> Items ++ A
-                         end
-                 end,
+    IsCount    = proplists:get_value(<<"Select">>, UserRequest) =:= <<"COUNT">>,
+    Accumulate = get_accumulate_fun(IsCount),
 
     case retry(scan, {UserRequest}, Opts) of
         {ok, {Response}} ->
@@ -378,7 +361,6 @@ do_scan({UserRequest}, Acc, Opts) ->
     end.
 
 
-
 %%
 %% INTERNALS
 %%
@@ -390,68 +372,45 @@ update_query(Request, Key, Value) ->
 retry(Op, Request, Opts) ->
     Body = encode_body(Op, Request),
     case proplists:is_defined(no_retry, Opts) of
-        true ->
-            do(Op, Body, timeout(Opts));
-        false ->
-            retry(Op, Body, 0, os:timestamp(), Opts)
+        true  -> do(Op, Body, opts_timeout(Opts));
+        false -> retry(Op, Body, 0, os:timestamp(), Opts)
     end.
 
 retry(Op, Body, Retries, Start, Opts) ->
     RequestStart = os:timestamp(),
     case do(Op, Body, Opts) of
         {ok, Response} ->
-
             case proplists:get_value(<<"ConsumedCapacity">>,
                                      element(1, Response)) of
-                undefined -> ok;
-                Capacity  -> catch (callback_mod()):request_complete(
-                                     Op, RequestStart, Capacity)
+                undefined ->
+                    ok;
+                Capacity  ->
+                    catch (config_callback_mod()):request_complete(
+                            Op, RequestStart, Capacity)
             end,
-
             {ok, Response};
-
         {error, Reason} = Error ->
-            catch (callback_mod()):request_error(Op, RequestStart, Reason),
+            catch (config_callback_mod()):request_error(Op, RequestStart, Reason),
 
             case should_retry(Reason) of
-                true ->
-                    case Retries =:= retries(Opts) of
-                        true ->
-                            {error, max_retries};
-                        false ->
-                            BackoffTime = min(max_backoff(Opts),
-                                              trunc(math:pow(2, Retries) * 50)),
-                            timer:sleep(BackoffTime),
-                            retry(Op, Body, Retries+1, Start, Opts)
-                    end;
-                false ->
-                    Error
+                true  -> apply_backpressure(Op, Body, Retries, Start, Opts);
+                false -> Error
             end
     end.
-
 
 do(Operation, Body, Opts) ->
     Now = edatetime:now2ts(),
 
-    URL = <<"http://", (endpoint())/binary, "/">>,
-    Headers = [
-               {<<"Host">>, endpoint()},
+    URL = <<"http://", (config_endpoint())/binary, "/">>,
+    Headers = [{<<"Host">>,         config_endpoint()},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
-               {<<"x-amz-date">>, edatetime:iso8601(Now)},
+               {<<"x-amz-date">>,   edatetime:iso8601(Now)},
                {<<"x-amz-target">>, target(Operation)}
               ],
     Signed = [{<<"Authorization">>, authorization(Headers, Body, Now)}
               | Headers],
 
-    ServerTimeout = proplists:get_value(server_timeout, Opts, 5000),
-    CallTimeout = proplists:get_value(call_timeout, Opts, 10000),
-    ClaimTimeout = proplists:get_value(claim_timeout, Opts, 1000), %% us
-    PartySocket = proplists:get_value(party_socket, Opts),
-
-    case party:post(URL, Signed, Body, [{server_timeout, ServerTimeout},
-                                        {call_timeout, CallTimeout},
-                                        {claim_timeout, ClaimTimeout},
-                                        {party_socket, PartySocket}]) of
+    case current_http_client:post(URL, Signed, Body, Opts) of
         {ok, {{200, _}, _, ResponseBody}} ->
             {ok, jiffy:decode(ResponseBody)};
 
@@ -486,10 +445,16 @@ do(Operation, Body, Opts) ->
             {error, Reason}
     end.
 
-
-timeout(Opts)     -> proplists:get_value(timeout, Opts, 5000).
-retries(Opts)     -> proplists:get_value(retries, Opts, 3).
-max_backoff(Opts) -> proplists:get_value(max_backoff, Opts, 60000).
+apply_backpressure(Op, Body, Retries, Start, Opts) ->
+    case Retries =:= opts_retries(Opts) of
+        true ->
+            {error, max_retries};
+        false ->
+            BackoffTime = min(opts_max_backoff(Opts),
+                              trunc(math:pow(2, Retries) * 50)),
+            timer:sleep(BackoffTime),
+            retry(Op, Body, Retries + 1, Start, Opts)
+    end.
 
 
 %%
@@ -530,15 +495,15 @@ canonical(Headers, Body) ->
 string_to_sign(HashedCanonicalRequest, Now) ->
     ["AWS4-HMAC-SHA256", "\n",
      binary_to_list(edatetime:iso8601_basic(Now)), "\n",
-     [ymd(Now), "/", region(), "/", aws_host(), "/aws4_request"], "\n",
-     HashedCanonicalRequest].
+     [format_ymd(Now), "/", config_region(), "/", config_aws_host(),
+      "/aws4_request"], "\n", HashedCanonicalRequest].
 
 
 derived_key(Now) ->
-    Secret = ["AWS4", secret_key()],
-    Date = hmac:hmac256(Secret, ymd(Now)),
-    Region = hmac:hmac256(Date, region()),
-    Service = hmac:hmac256(Region, aws_host()),
+    Secret = ["AWS4", config_secret_key()],
+    Date = hmac:hmac256(Secret, format_ymd(Now)),
+    Region = hmac:hmac256(Date, config_region()),
+    Service = hmac:hmac256(Region, config_aws_host()),
     hmac:hmac256(Service, "aws4_request").
 
 
@@ -548,15 +513,9 @@ signature(StringToSign, Now) ->
         hmac:hmac256(derived_key(Now),
                      StringToSign))).
 
-
-
 credential(Now) ->
-    [access_key(), "/", ymd(Now), "/", region(), "/", aws_host(), "/aws4_request"].
-
-hexdigest(Body) ->
-    to_lower(hmac:hexlify(erlsha2:sha256(Body))).
-
-
+    [config_access_key(), "/", format_ymd(Now), "/", config_region(), "/",
+     config_aws_host(), "/aws4_request"].
 
 target(batch_get_item)   -> <<"DynamoDB_20120810.BatchGetItem">>;
 target(batch_write_item) -> <<"DynamoDB_20120810.BatchWriteItem">>;
@@ -597,11 +556,6 @@ should_retry(max_concurrency)                                   -> true.
 %% INTERNAL HELPERS
 %%
 
-to_lower(Binary) when is_binary(Binary) ->
-    string:to_lower(binary_to_list(Binary));
-to_lower(List) ->
-    string:to_lower(List).
-
 encode_body(Operation, {UserRequest}) ->
     Request = case Operation of
                   Op when Op =:= delete_table;
@@ -615,32 +569,47 @@ encode_body(Operation, {UserRequest}) ->
               end,
     jiffy:encode(Request).
 
-region() ->
+%% Configuration
+config_region() ->
     {ok, Region} = application:get_env(current, region),
     Region.
 
-endpoint() ->
+config_endpoint() ->
     case application:get_env(current, endpoint) of
         {ok, Endpoint} ->
             Endpoint;
         undefined ->
-            <<"dynamodb.", (region())/binary, ".amazonaws.com">>
+            <<"dynamodb.", (config_region())/binary, ".amazonaws.com">>
     end.
 
-aws_host() ->
+config_aws_host() ->
     application:get_env(current, aws_host, <<"dynamodb">>).
 
-access_key() ->
+config_access_key() ->
     {ok, Access} = application:get_env(current, access_key),
     Access.
 
-secret_key() ->
+config_secret_key() ->
     {ok, Secret} = application:get_env(current, secret_access_key),
     Secret.
 
-ymd(Now) ->
+config_callback_mod() ->
+    application:get_env(current, callback_mod, current_callback).
+
+%% Options
+opts_timeout(Opts)     -> proplists:get_value(timeout, Opts, 5000).
+opts_retries(Opts)     -> proplists:get_value(retries, Opts, 3).
+opts_max_backoff(Opts) -> proplists:get_value(max_backoff, Opts, 60000).
+
+%% Formatting helpers
+hexdigest(Body) ->
+    to_lower(hmac:hexlify(erlsha2:sha256(Body))).
+
+format_ymd(Now) ->
     {Y, M, D} = edatetime:ts2date(Now),
     io_lib:format("~4.10.0B~2.10.0B~2.10.0B", [Y, M, D]).
 
-callback_mod() ->
-    application:get_env(current, callback_mod, current_callback).
+to_lower(Binary) when is_binary(Binary) ->
+    string:to_lower(binary_to_list(Binary));
+to_lower(List) ->
+    string:to_lower(List).

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -1,22 +1,33 @@
+%% @doc HTTP client wrapper
 -module(current_http_client).
--include_lib("eunit/include/eunit.hrl").
 
+%% API
 -export([post/4]).
 
--type headers()        :: list({binary(), any()}).
+%%
+%% TYPES
+%%
+-type header()         :: {binary() | string(), any()}.
+-type headers()        :: [header()].
+-type body()           :: iolist() | binary().
 -type options()        :: list({atom(), any()}).
--type response_ok()    :: {ok, {{integer(), string()}, headers(), binary()}}.
+-type response_ok()    :: {ok, {{integer(), string()}, headers(), body()}}.
 -type response_error() :: {error, any()}.
 
-%%TODO: map options
+
+%%
+%% API
+%%
+%%FIXME: unify retry config
 %%TODO: how to handle that party:connect abstraction leak?
--spec post(binary(), headers(), binary(), options()) ->
+-spec post(binary(), headers(), body(), options()) ->
                   response_ok() | response_error().
 post(URL, Headers, Body, Opts) ->
-    ServerTimeout = proplists:get_value(server_timeout, Opts, 5000),
-    CallTimeout   = proplists:get_value(call_timeout, Opts, 10000),
-    ClaimTimeout  = proplists:get_value(claim_timeout, Opts, 1000), %% us
-    PartySocket   = proplists:get_value(party_socket, Opts, undefined),
+    ServerTimeout = proplists:get_value(server_timeout,  Opts, 5000),
+    CallTimeout   = proplists:get_value(call_timeout,    Opts, 10000),
+    ClaimTimeout  = proplists:get_value(claim_timeout,   Opts, 1000), %% us
+    PartySocket   = proplists:get_value(party_socket,    Opts, undefined),
+    MaxConns      = proplists:get_value(max_connections, Opts, 10),
 
     case config_http_client() =:= party of
         true  ->
@@ -26,9 +37,21 @@ post(URL, Headers, Body, Opts) ->
                        {party_socket,   PartySocket}],
             party:post(URL, Headers, Body, Options);
         false ->
-            Options = [{connect_timeout, CallTimeout}],
-            lhttpc:request(URL, post, Headers, Body, Options)
+            Options = [{connect_timeout, CallTimeout},
+                       {max_connections, MaxConns},
+                       {send_retry,      3}],
+            lhttpc:request(to_list(URL), post,
+                           normalize_headers(Headers), Body,
+                           CallTimeout, Options)
     end.
 
+normalize_headers(Headers) ->
+    [{to_list(K), to_list(V)} || {K,V} <- Headers].
+
+to_list(B) when is_binary(B) ->
+    binary_to_list(B);
+to_list(L) ->
+    L.
+
 config_http_client() ->
-    application:get_env(current, http_client, party).
+    application:get_env(current, http_client, lhttpc).

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -45,7 +45,7 @@ post(URL, Headers, Body, Opts) ->
     end.
 
 is_party_active() ->
-    application:get_env(current, http_client, lhttpc) =:= party.
+    application:get_env(current, http_client, party) =:= party.
 
 
 %%

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -3,6 +3,7 @@
 
 %% API
 -export([post/4]).
+-export([is_party_active/0]).
 
 %%
 %% TYPES
@@ -28,7 +29,7 @@ post(URL, Headers, Body, Opts) ->
     PartySocket   = proplists:get_value(party_socket,    Opts, undefined),
     MaxConns      = proplists:get_value(max_connections, Opts, 10),
 
-    case config_http_client() =:= party of
+    case is_party_active() of
         true  ->
             Options = [{server_timeout, ServerTimeout},
                        {call_timeout,   CallTimeout},
@@ -43,6 +44,13 @@ post(URL, Headers, Body, Opts) ->
                            CallTimeout, Options)
     end.
 
+is_party_active() ->
+    application:get_env(current, http_client, lhttpc) =:= party.
+
+
+%%
+%% INTERNALS
+%%
 normalize_headers(Headers) ->
     [{to_list(K), to_list(V)} || {K,V} <- Headers].
 
@@ -50,6 +58,3 @@ to_list(B) when is_binary(B) ->
     binary_to_list(B);
 to_list(L) ->
     L.
-
-config_http_client() ->
-    application:get_env(current, http_client, lhttpc).

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -18,7 +18,6 @@
 %%
 %% API
 %%
-%%FIXME: unify retry config
 %%TODO: how to handle that party:connect abstraction leak?
 -spec post(binary(), headers(), body(), options()) ->
                   response_ok() | response_error().
@@ -38,8 +37,7 @@ post(URL, Headers, Body, Opts) ->
             party:post(URL, Headers, Body, Options);
         false ->
             Options = [{connect_timeout, CallTimeout},
-                       {max_connections, MaxConns},
-                       {send_retry,      3}],
+                       {max_connections, MaxConns}],
             lhttpc:request(to_list(URL), post,
                            normalize_headers(Headers), Body,
                            CallTimeout, Options)

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -44,6 +44,7 @@ post(URL, Headers, Body, Opts) ->
                            CallTimeout, Options)
     end.
 
+-spec is_party_active() -> boolean().
 is_party_active() ->
     application:get_env(current, http_client, party) =:= party.
 

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -1,0 +1,34 @@
+-module(current_http_client).
+-include_lib("eunit/include/eunit.hrl").
+
+-export([post/4]).
+
+-type headers()        :: list({binary(), any()}).
+-type options()        :: list({atom(), any()}).
+-type response_ok()    :: {ok, {{integer(), string()}, headers(), binary()}}.
+-type response_error() :: {error, any()}.
+
+%%TODO: map options
+%%TODO: how to handle that party:connect abstraction leak?
+-spec post(binary(), headers(), binary(), options()) ->
+                  response_ok() | response_error().
+post(URL, Headers, Body, Opts) ->
+    ServerTimeout = proplists:get_value(server_timeout, Opts, 5000),
+    CallTimeout   = proplists:get_value(call_timeout, Opts, 10000),
+    ClaimTimeout  = proplists:get_value(claim_timeout, Opts, 1000), %% us
+    PartySocket   = proplists:get_value(party_socket, Opts, undefined),
+
+    case config_http_client() =:= party of
+        true  ->
+            Options = [{server_timeout, ServerTimeout},
+                       {call_timeout,   CallTimeout},
+                       {claim_timeout,  ClaimTimeout},
+                       {party_socket,   PartySocket}],
+            party:post(URL, Headers, Body, Options);
+        false ->
+            Options = [{connect_timeout, CallTimeout}],
+            lhttpc:request(URL, post, Headers, Body, Options)
+    end.
+
+config_http_client() ->
+    application:get_env(current, http_client, party).

--- a/test/current_test.erl
+++ b/test/current_test.erl
@@ -15,18 +15,18 @@
 current_test_() ->
     {setup, fun setup/0, fun teardown/1,
      [
-      {timeout, 120, ?_test(table_manipulation())},
-      {timeout, 30,  ?_test(batch_get_write_item())},
-      {timeout, 30,  ?_test(batch_get_unprocessed_items())},
-      {timeout, 30,  ?_test(scan())},
-      {timeout, 30,  ?_test(q())},
-      {timeout, 30,  ?_test(get_put_update_delete())},
-      {timeout, 30,  ?_test(retry_with_timeout())},
-      {timeout, 30,  ?_test(timeout())},
-      {timeout, 30,  ?_test(throttled())},
-      {timeout, 30,  ?_test(non_json_error())},
-      {timeout, 30,  ?_test(http_client())},
-      {timeout, 30,  ?_test(raw_socket())}
+      %% {timeout, 120, ?_test(table_manipulation())},
+      %% {timeout, 30,  ?_test(batch_get_write_item())},
+      %% {timeout, 30,  ?_test(batch_get_unprocessed_items())},
+      %% {timeout, 30,  ?_test(scan())},
+      %% {timeout, 30,  ?_test(q())},
+      %% {timeout, 30,  ?_test(get_put_update_delete())},
+      %% {timeout, 30,  ?_test(retry_with_timeout())},
+      %% {timeout, 30,  ?_test(timeout())},
+      %% {timeout, 30,  ?_test(throttled())},
+      %% {timeout, 30,  ?_test(non_json_error())},
+      {timeout, 30,  ?_test(http_client())}
+      %% {timeout, 30,  ?_test(raw_socket())}
      ]}.
 
 
@@ -492,6 +492,7 @@ raw_socket() ->
 
     ok.
 
+
 %%
 %% HELPERS
 %%
@@ -543,9 +544,10 @@ setup() ->
     application:set_env(current, access_key, AccessKey),
     application:set_env(current, secret_access_key, SecretAccessKey),
 
-    ok = party:connect(iolist_to_binary(["http://", ?ENDPOINT]), 2),
+    {ok, _} = application:ensure_all_started(current),
 
-    {ok, _} = application:ensure_all_started(current).
+    %%ok = current:connect(iolist_to_binary(["http://", ?ENDPOINT]), 2).
+    ok.
 
 teardown(_) ->
     application:stop(current).

--- a/test/current_test.erl
+++ b/test/current_test.erl
@@ -15,18 +15,18 @@
 current_test_() ->
     {setup, fun setup/0, fun teardown/1,
      [
-      %% {timeout, 120, ?_test(table_manipulation())},
-      %% {timeout, 30,  ?_test(batch_get_write_item())},
-      %% {timeout, 30,  ?_test(batch_get_unprocessed_items())},
-      %% {timeout, 30,  ?_test(scan())},
-      %% {timeout, 30,  ?_test(q())},
-      %% {timeout, 30,  ?_test(get_put_update_delete())},
-      %% {timeout, 30,  ?_test(retry_with_timeout())},
-      %% {timeout, 30,  ?_test(timeout())},
-      %% {timeout, 30,  ?_test(throttled())},
-      %% {timeout, 30,  ?_test(non_json_error())},
-      {timeout, 30,  ?_test(http_client())}
-      %% {timeout, 30,  ?_test(raw_socket())}
+      {timeout, 120, ?_test(table_manipulation())},
+      {timeout, 30,  ?_test(batch_get_write_item())},
+      {timeout, 30,  ?_test(batch_get_unprocessed_items())},
+      {timeout, 30,  ?_test(scan())},
+      {timeout, 30,  ?_test(q())},
+      {timeout, 30,  ?_test(get_put_update_delete())},
+      {timeout, 30,  ?_test(retry_with_timeout())},
+      {timeout, 30,  ?_test(timeout())},
+      {timeout, 30,  ?_test(throttled())},
+      {timeout, 30,  ?_test(non_json_error())},
+      {timeout, 30,  ?_test(http_client())},
+      {timeout, 30,  ?_test(raw_socket())}
      ]}.
 
 
@@ -128,9 +128,6 @@ batch_get_unprocessed_items() ->
 
     {ok, [{?TABLE_OTHER, Table1}, {?TABLE, Table2}]} =
         current:batch_get_item(GetRequest, []),
-
-    file:write_file("/tmp/1.txt", io_lib:format("~p", [key_sort(Keys)]), [write]),
-    file:write_file("/tmp/2.txt", io_lib:format("~p", [key_sort(Table1)]), [write]),
 
     ?assertEqual(key_sort(Keys), key_sort(Table1)),
     ?assertEqual(key_sort(Keys), key_sort(Table2)),
@@ -469,6 +466,7 @@ post_vanilla_test() ->
 
 http_client() ->
     ?assertEqual(ok, application:set_env(current, http_client, party)),
+    ok = connect_party(),
     current:delete_table({[{<<"TableName">>, ?TABLE}]}),
     ?assertNotEqual({ok, lhttpc}, application:get_env(current, http_client)),
     ?assertEqual(ok, current:wait_for_delete(?TABLE, 5000)),
@@ -496,6 +494,9 @@ raw_socket() ->
 %%
 %% HELPERS
 %%
+
+connect_party() ->
+    ok = current:connect(iolist_to_binary(["http://", ?ENDPOINT]), 2).
 
 creq(Name) ->
     {ok, B} = file:read_file(
@@ -546,7 +547,8 @@ setup() ->
 
     {ok, _} = application:ensure_all_started(current),
 
-    %%ok = current:connect(iolist_to_binary(["http://", ?ENDPOINT]), 2).
+    ok = connect_party(),
+
     ok.
 
 teardown(_) ->

--- a/test/current_test.erl
+++ b/test/current_test.erl
@@ -481,16 +481,16 @@ http_client() ->
 raw_socket() ->
     ?assertEqual(ok, application:set_env(current, http_client, lhttpc)),
     ?assertEqual({error,raw_socket_not_supported},
-                 current:open_socket(?ENDPOINT, raw)),
+                 current:open_socket(?ENDPOINT, party_socket)),
 
     ?assertEqual(ok, application:set_env(current, http_client, party)),
-    {Reply, Socket} = current:open_socket(?ENDPOINT, raw),
+    {Reply, Socket} = current:open_socket(?ENDPOINT, party_socket),
     ?assertEqual(ok, Reply),
 
     current:delete_table({[{<<"TableName">>, ?TABLE}]}),
     ?assertEqual(ok, current:wait_for_delete(?TABLE, 5000)),
 
-    ?assertEqual(ok, current:close_socket(Socket, raw)),
+    ?assertEqual(ok, current:close_socket(Socket, party_socket)),
 
     ok.
 

--- a/test/current_test.erl
+++ b/test/current_test.erl
@@ -25,7 +25,8 @@ current_test_() ->
       {timeout, 30,  ?_test(timeout())},
       {timeout, 30,  ?_test(throttled())},
       {timeout, 30,  ?_test(non_json_error())},
-      {timeout, 30,  ?_test(http_client())}
+      {timeout, 30,  ?_test(http_client())},
+      {timeout, 30,  ?_test(raw_socket())}
      ]}.
 
 
@@ -479,6 +480,17 @@ http_client() ->
 
     ok.
 
+raw_socket() ->
+    ?assertEqual(ok, application:set_env(current, http_client, lhttpc)),
+    ?assertEqual({error,raw_socket_not_supported},
+                 current:open_socket(?ENDPOINT, raw)),
+
+    ?assertEqual(ok, application:set_env(current, http_client, party)),
+    {Reply, Socket} = current:open_socket(?ENDPOINT, raw),
+    ?assertEqual(ok, Reply),
+    ?assertEqual(ok, current:close_socket(Socket, raw)),
+
+    ok.
 
 %%
 %% HELPERS

--- a/test/current_test.erl
+++ b/test/current_test.erl
@@ -466,7 +466,7 @@ post_vanilla_test() ->
 
 http_client() ->
     ?assertEqual(ok, application:set_env(current, http_client, party)),
-    ok = connect_party(),
+    ok = maybe_connect_party(),
     current:delete_table({[{<<"TableName">>, ?TABLE}]}),
     ?assertNotEqual({ok, lhttpc}, application:get_env(current, http_client)),
     ?assertEqual(ok, current:wait_for_delete(?TABLE, 5000)),
@@ -486,6 +486,10 @@ raw_socket() ->
     ?assertEqual(ok, application:set_env(current, http_client, party)),
     {Reply, Socket} = current:open_socket(?ENDPOINT, raw),
     ?assertEqual(ok, Reply),
+
+    current:delete_table({[{<<"TableName">>, ?TABLE}]}),
+    ?assertEqual(ok, current:wait_for_delete(?TABLE, 5000)),
+
     ?assertEqual(ok, current:close_socket(Socket, raw)),
 
     ok.
@@ -495,8 +499,8 @@ raw_socket() ->
 %% HELPERS
 %%
 
-connect_party() ->
-    ok = current:connect(iolist_to_binary(["http://", ?ENDPOINT]), 2).
+maybe_connect_party() ->
+    current:connect(iolist_to_binary(["http://", ?ENDPOINT]), 2).
 
 creq(Name) ->
     {ok, B} = file:read_file(
@@ -547,7 +551,7 @@ setup() ->
 
     {ok, _} = application:ensure_all_started(current),
 
-    ok = connect_party(),
+    maybe_connect_party(),
 
     ok.
 


### PR DESCRIPTION
Allow user to swap between HTTP clients (`party` and `lhttpc`).
Reasoning behind is that `party` is not HTTP 1.1 compliant and DynamoDB sometimes sends chunked responses (which real DynamoDB could do as well in theory). This PR also tries to hide HTTP client specifics behind API (eg. `party:connect/2` or `party_socket_raw`).