### PR TITLE
List Tables doesn't support ReturnConsumedCapacity

### DIFF
--- a/src/current.erl
+++ b/src/current.erl
@@ -616,6 +616,7 @@ encode_body(Operation, {UserRequest}) ->
     Request = case Operation of
                   Op when Op =:= delete_table;
                           Op =:= describe_table;
+                          Op =:= list_tables;                          
                           Op =:= create_table ->
                       {UserRequest};
                   _Other ->


### PR DESCRIPTION
http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html doesn't list it