### PR TITLE
If DynamoDB changes version, still match

### DIFF
--- a/src/current.erl
+++ b/src/current.erl
@@ -480,6 +480,8 @@ do(Operation, Body, Opts) ->
                            <<"com.amazon.coral.validate#", T/binary>> ->
                                T;
                            <<"com.amazon.coral.service#", T/binary>> ->
+                               T;
+                           <<"com.amazonaws.dynamodb.v", T/binary>> ->
                                T
                        end,
                 Message = case proplists:get_value(<<"message">>, Response) of


### PR DESCRIPTION
This means that Current keeps working even if the version changes (or if someone for some reason is using a different version), otherwise we get a case_clause error