### PR TITLE
If we run out of retries, tell the end user the full reason for failure

### DIFF
--- a/src/current.erl
+++ b/src/current.erl
@@ -449,7 +449,7 @@ retry(Op, Body, Retries, Start, Opts) ->
             catch (config_callback_mod()):request_error(Op, RequestStart, Reason),
 
             case should_retry(Reason) of
-                true  -> apply_backpressure(Op, Body, Retries, Start, Opts);
+                true  -> apply_backpressure(Op, Body, Retries, Start, Opts, Reason);
                 false -> Error
             end
     end.
@@ -501,10 +501,10 @@ do(Operation, Body, Opts) ->
             {error, Reason}
     end.
 
-apply_backpressure(Op, Body, Retries, Start, Opts) ->
+apply_backpressure(Op, Body, Retries, Start, Opts, Reason) ->
     case Retries =:= opts_retries(Opts) of
         true ->
-            {error, max_retries};
+            {error, max_retries, Reason};
         false ->
             BackoffTime = min(opts_max_backoff(Opts),
                               trunc(math:pow(2, Retries) * 50)),

--- a/test/current_test.erl
+++ b/test/current_test.erl
@@ -367,7 +367,7 @@ retry_with_timeout() ->
     meck:unload(current_http_client).
 
 timeout() ->
-    ?assertEqual({error, max_retries, claim_timeout},
+    ?assertEqual({error, max_retries, timeout},
                  current:describe_table({[{<<"TableName">>, ?TABLE}]},
                                         [{call_timeout, 1}])).
 

--- a/test/current_test.erl
+++ b/test/current_test.erl
@@ -360,14 +360,14 @@ retry_with_timeout() ->
     meck:expect(current_http_client, post, fun (_, _, _, _) ->
                                                    {error, claim_timeout}
                                            end),
-    ?assertEqual({error, max_retries},
+    ?assertEqual({error, max_retries, claim_timeout},
                  current:describe_table({[{<<"TableName">>, ?TABLE}]},
                                         [{retries, 3}])),
 
     meck:unload(current_http_client).
 
 timeout() ->
-    ?assertEqual({error, max_retries},
+    ?assertEqual({error, max_retries, claim_timeout},
                  current:describe_table({[{<<"TableName">>, ?TABLE}]},
                                         [{call_timeout, 1}])).
 


### PR DESCRIPTION
I want to be able to find out what the problem is if the retry count runs out entirely, and currently I just get `{error, max_retries}` which isn't very useful. This PR appends the reason to that.