### PR TITLE
GAME-4308 Return correct error tuple when max retries is reached in a…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: erlang
-otp_release:
-    - R16B02
 sudo: false
+branches:
+  only:
+      - master
+      - /^game-\d+$/
+notifications:
+     email:
+         - backend@gameanalytics.com
+otp_release:
+    - 19.1
+    - R16B03
 addons:
   apt:
     packages:

--- a/src/current.app.src
+++ b/src/current.app.src
@@ -1,7 +1,7 @@
 {application, current,
  [
   {description, "DynamoDB client"},
-  {vsn, "0.1"},
+  {vsn, "0.1.1"},
   {registered, []},
   {applications, [
                   kernel,

--- a/src/current.erl
+++ b/src/current.erl
@@ -36,10 +36,15 @@
 -export([open_socket/2, close_socket/2]).
 -export([wait_for_delete/2, wait_for_active/2]).
 
-
-%% Exported for testing
--export([take_get_batch/2, take_write_batch/2]).
--export([derived_key/1, canonical/2, string_to_sign/2, authorization/3]).
+-ifdef(TEST).
+-export([take_get_batch/2,
+         take_write_batch/2,
+         derived_key/1,
+         canonical/2,
+         string_to_sign/2,
+         authorization/3,
+         apply_backpressure/6]).
+-endif.
 
 
 %%
@@ -506,7 +511,7 @@ do(Operation, Body, Opts) ->
 apply_backpressure(Op, Body, Retries, Start, Opts, Reason) ->
     case Retries =:= opts_retries(Opts) of
         true ->
-            {error, max_retries, Reason};
+            {error, {max_retries, Reason}};
         false ->
             BackoffTime = min(opts_max_backoff(Opts),
                               trunc(math:pow(2, Retries) * 50)),


### PR DESCRIPTION
…pply_backpressure

* instead of a 3 element tuple return a expected 2 element tuple with nested error reason
* updating travis config
* correcting test cases
* adding in a new test case for regression testing