### PR TITLE
Send case sensitive headers to AWS 

### DIFF
--- a/src/current.erl
+++ b/src/current.erl
@@ -405,8 +405,8 @@ do(Operation, Body, Opts) ->
     URL = <<"http://", (config_endpoint())/binary, "/">>,
     Headers = [{<<"Host">>,         config_endpoint()},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
-               {<<"x-amz-date">>,   edatetime:iso8601(Now)},
-               {<<"x-amz-target">>, target(Operation)}
+               {<<"X-Amz-Date">>,   edatetime:iso8601(Now)},
+               {<<"x-Amz-Target">>, target(Operation)}
               ],
     Signed = [{<<"Authorization">>, authorization(Headers, Body, Now)}
               | Headers],

--- a/src/current.erl
+++ b/src/current.erl
@@ -406,7 +406,7 @@ do(Operation, Body, Opts) ->
     Headers = [{<<"Host">>,         config_endpoint()},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
                {<<"X-Amz-Date">>,   edatetime:iso8601(Now)},
-               {<<"x-Amz-Target">>, target(Operation)}
+               {<<"X-Amz-Target">>, target(Operation)}
               ],
     Signed = [{<<"Authorization">>, authorization(Headers, Body, Now)}
               | Headers],

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -23,7 +23,7 @@
 post(URL, Headers, Body, Opts) ->
     CallTimeout   = proplists:get_value(call_timeout,    Opts, 10000),
     Request = {to_list(URL), normalize_headers(Headers), "", Body},
-    Options = [{body_format, binary}],
+    Options = [{body_format, binary}, {headers_as_is, true}],
     case httpc:request(post, Request, [{timeout, CallTimeout}], Options) of
         {ok,{{_,Code,_},_Headers, RetBody}} ->
             {ok, Code, RetBody};

--- a/src/current_http_client.erl
+++ b/src/current_http_client.erl
@@ -22,7 +22,8 @@
                   response_ok() | response_error().
 post(URL, Headers, Body, Opts) ->
     CallTimeout   = proplists:get_value(call_timeout,    Opts, 10000),
-    Request = {to_list(URL), normalize_headers(Headers), "", Body},
+    Headers2 = [{"Content-Length", integer_to_list(erlang:size(Body))} | Headers],
+    Request = {to_list(URL), normalize_headers(Headers2), "", Body},
     Options = [{body_format, binary}, {headers_as_is, true}],
     case httpc:request(post, Request, [{timeout, CallTimeout}], Options) of
         {ok,{{_,Code,_},_Headers, RetBody}} ->


### PR DESCRIPTION
We need to send case sensitive headers to AWS services as they being used to calculate signature.